### PR TITLE
Fix getCheckoutPayload by pulling from lineItem.properties and not customAttributes

### DIFF
--- a/extensions/custom-pixels/src/index.ts
+++ b/extensions/custom-pixels/src/index.ts
@@ -5,6 +5,7 @@ type CartAttribute = {
   key: string
   value: string
 }
+
 function getDeviceIDFromEvent (event) {
   const attributes = (event?.checkout?.attributes || []) as CartAttribute[]
   const deviceIDAttribute = attributes.find(attr => attr.key === '_amplitudeDeviceId')
@@ -13,7 +14,7 @@ function getDeviceIDFromEvent (event) {
 
 function getCheckoutPayload (checkout) {
   const distinctLineItems = checkout.lineItems.filter((lineItem) => {
-    const properties = Object.fromEntries(lineItem.customAttributes.map(attr => [attr.key, attr.value]))
+    const properties = Object.fromEntries(lineItem.properties.map(attr => [attr.key, attr.value]))
 
     // If the line item has no _bundleId and _baseVariantId then it's distinct
     if (!properties._bundleId && !properties._baseVariantId) return true
@@ -60,14 +61,16 @@ function getCheckoutPayload (checkout) {
   }
 }
 
-register(({ analytics, browser, init, settings }) => {
+register(({ analytics, settings }) => {
   amplitude.getInstance().init(settings.amplitudeAPIKey)
 
   analytics.subscribe("all_standard_events", event => {
     // Ensure we have the correct device ID to be consistent with storefront
     const cartAmplitudeDeviceId = getDeviceIDFromEvent(event?.data)
+
     const activeAmplitudeDeviceId = amplitude.getInstance().getDeviceId()
     console.log(cartAmplitudeDeviceId, activeAmplitudeDeviceId)
+
     if (cartAmplitudeDeviceId && (cartAmplitudeDeviceId !== activeAmplitudeDeviceId)) {
       amplitude.getInstance().setDeviceId(cartAmplitudeDeviceId)
     }

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -3,7 +3,7 @@
 client_id = "368fb974941b9e331b6c0899c2d520f1"
 name = "SunGod External"
 handle = "sungod-external"
-application_url = "https://inspector-press-done-lid.trycloudflare.com"
+application_url = "https://double-computer-opposition-bite.trycloudflare.com"
 embedded = true
 
 [build]
@@ -17,9 +17,9 @@ scopes = "read_checkouts,read_customer_events,read_discounts,read_metaobject_def
 
 [auth]
 redirect_urls = [
-  "https://inspector-press-done-lid.trycloudflare.com/auth/callback",
-  "https://inspector-press-done-lid.trycloudflare.com/auth/shopify/callback",
-  "https://inspector-press-done-lid.trycloudflare.com/api/auth/callback"
+  "https://double-computer-opposition-bite.trycloudflare.com/auth/callback",
+  "https://double-computer-opposition-bite.trycloudflare.com/auth/shopify/callback",
+  "https://double-computer-opposition-bite.trycloudflare.com/api/auth/callback"
 ]
 
 [webhooks]


### PR DESCRIPTION
Tracking was not firing due to an error in getCheckoutPayload on running filter on a non existent key.

Now correctly tracks the event:

<img width="619" alt="Screenshot 2024-08-27 at 15 29 15" src="https://github.com/user-attachments/assets/a7bd8959-0b81-4a27-9d6b-cc482240f713">
